### PR TITLE
feat: add reusable retention workflow for workflow runs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -20,5 +20,5 @@
   "loadDefaultConfiguration": true,
   "useGitignore": true,
   "ignoreWords": ["jfandy1982"],
-  "words": []
+  "words": ["Mattraks"]
 }

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,10 @@
+name: Local Housekeeping
+
+on:
+  schedule:
+    - cron: '08 04 * * 5'
+  workflow_dispatch:
+
+jobs:
+  retention:
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-retention-workflow-runs.yml@main

--- a/.github/workflows/reusable-retention-workflow-runs.yml
+++ b/.github/workflows/reusable-retention-workflow-runs.yml
@@ -1,0 +1,21 @@
+name: Reusable - Retention of Workflow Runs
+
+on:
+  workflow_call:
+
+jobs:
+  delete-runs:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Delete outdated workflow runs
+        uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee # v2.1.0
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 0
+          keep_minimum_runs: 0
+          delete_workflow_by_state_pattern: ALL
+          delete_run_by_conclusion_pattern: ALL

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-  "**/*.{json,md,yml,yaml}": ["prettier --write", "cspell lint --no-must-find-files --no-progress"]
+  "**/*.{json,md,yml,yaml}": ["prettier --write", "cspell lint --no-must-find-files --no-progress"],
+  "**/*.{yml,yaml}": ["js-yaml"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ This is the GitHub repository containing reusable GitHub Workflows.
 
 ## Known structure
 
-- `.github/workflows/` — reusable workflows (via `workflow_call`) and scheduled/dispatched runs for this repo itself
+- `.github/workflows/` — two types of files:
+  - Reusable workflows: `reusable-<purpose>-<scope>.yml` — callable via `workflow_call` from other repos
+  - Local orchestrators: `<purpose>.yml` — triggers scoped to this repo only
+- `.github/actions/` — composite actions (not yet created, reserved for future use)
 - `experiments/` — deliberate playground and backup directory, not production code; ignore when reviewing
 - `node_modules/` — exists locally but is gitignored; not committed to the repo
 
@@ -14,4 +17,5 @@ This is the GitHub repository containing reusable GitHub Workflows.
 
 - GitHub Actions SHAs are manually verified and pinned — do not flag pinned SHAs as outdated without checking first
 - Renovate: `renovate.json` in `.github/` is the repository-specific Renovate entry point; the `schedule` override there is intentional
-- pre-commit hook runs `lint-staged` (Prettier + cspell) on `*.json`, `*.md`, `*.yml`
+- pre-commit hook runs `lint-staged` (Prettier + cspell) on `*.json`, `*.md`, `*.yml`; additionally runs `js-yaml` syntax validation on `*.yml`, `*.yaml`
+- Workflow `name:` field convention: `Reusable - <Purpose>` for reusable workflows, `Local <Purpose>` for orchestrators

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This is the GitHub repository containing reusable GitHub Workflows.
   - Local orchestrators: `<purpose>.yml` — triggers scoped to this repo only
 - `.github/actions/` — composite actions (not yet created, reserved for future use)
 - `experiments/` — deliberate playground and backup directory, not production code; ignore when reviewing
+  - `experiments/superpowers/` — brainstorming specs and implementation plans from Claude sessions (gitignored, local only); check here for prior design decisions before starting new work
 - `node_modules/` — exists locally but is gitignored; not committed to the repo
 
 ## Tooling

--- a/README.md
+++ b/README.md
@@ -4,23 +4,16 @@ Reusable GitHub Actions workflows for all repositories owned by [@jfandy1982](ht
 
 ## Available Workflows
 
-### Garbage Collection (`retention_period.yml`)
+### Garbage Collection (`reusable-retention-workflow-runs.yml`)
 
-Deletes outdated workflow runs based on a configurable retention period.
+Deletes all workflow runs (and their associated artifacts) in the calling repository. No age filter, no minimum — complete cleanup on every run.
 
 **Usage in other repos:**
 
 ```yaml
 jobs:
   retention:
-    uses: jfandy1982/shared-github-workflows/.github/workflows/retention_period.yml@main
-    with:
-      days: '30'
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-retention-workflow-runs.yml@main
 ```
 
-**Inputs:**
-
-| Input | Required | Default | Description |
-| --- | --- | --- | --- |
-| `days` | no | `30` | Retention period in days |
-| `keep_minimum_runs` | no | `5` | Minimum runs to keep regardless of age |
+The calling workflow is responsible for defining its own trigger (schedule, dispatch, etc.). No inputs required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@cspell/dict-de-de": "^4.0.0",
         "cspell": "^9.0.0",
         "husky": "^9.0.0",
+        "js-yaml": "^4.1.1",
         "lint-staged": "^16.0.0",
         "prettier": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "format:all:check": "prettier --check .",
     "prepare": "husky || true",
     "spell:check:all": "cspell lint --dot --show-suggestions --no-progress --no-must-find-files --config ./.cspell.json .",
-    "spell:search:dict": "cspell trace --all --config ./.cspell.json"
+    "spell:search:dict": "cspell trace --all --config ./.cspell.json",
+    "yaml:all:check": "find .github/workflows -name '*.yml' -exec js-yaml {} \\;"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
@@ -14,6 +15,7 @@
     "@cspell/dict-de-de": "^4.0.0",
     "cspell": "^9.0.0",
     "husky": "^9.0.0",
+    "js-yaml": "^4.1.1",
     "lint-staged": "^16.0.0",
     "prettier": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "format:all": "prettier --write .",
     "format:all:check": "prettier --check .",
     "prepare": "husky || true",
-    "spell:check:all": "cspell lint --dot --show-suggestions --no-progress --no-must-find-files --config ./.cspell.json .",
-    "spell:search:dict": "cspell trace --all --config ./.cspell.json",
+    "spell:all:check": "cspell lint --dot --show-suggestions --no-progress --no-must-find-files --config ./.cspell.json .",
+    "spell:dict:search": "cspell trace --all --config ./.cspell.json",
     "yaml:all:check": "find .github/workflows -name '*.yml' -exec js-yaml {} \\;"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Adds `reusable-retention-workflow-runs.yml` — reusable workflow wrapping `Mattraks/delete-workflow-runs` (SHA-pinned to v2.1.0), deletes all workflow runs and associated artifacts with no restrictions
- Adds `housekeeping.yml` — local orchestrator for this repo, triggers weekly on Friday and on manual dispatch
- Adds `js-yaml` as explicit devDependency for YAML syntax validation in lint-staged pre-commit hook
- Aligns npm script naming to consistent `<tool>:<scope>:<mode>` convention
- Updates `CLAUDE.md` to reflect new naming conventions and tooling additions
- Updates `README.md` with correct workflow filename and usage example

## Notes

- `Mattraks` added to `.cspell.json` words list
- Artifacts are deleted implicitly when their parent workflow run is deleted (GitHub behavior)
- No inputs in v1 - all options fixed inside the reusable workflow; inputs will be added incrementally in future PRs