### PR TITLE
fix: grant permissions to reusable retention workflow caller

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -8,3 +8,6 @@ on:
 jobs:
   retention:
     uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-retention-workflow-runs.yml@main
+    permissions:
+      actions: write
+      contents: read


### PR DESCRIPTION
## Summary

- Adds `permissions` block to the `retention` job in `housekeeping.yml`
- GitHub Actions requires the caller to explicitly grant permissions that the reusable workflow's jobs request; without it the job defaults to `actions: none` causing a `startup_failure`