### PR TITLE
feat: add actionlint reusable workflow and caller

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -19,6 +19,6 @@
   "import": ["@cspell/dict-de-de/cspell-ext.json"],
   "loadDefaultConfiguration": true,
   "useGitignore": true,
-  "ignoreWords": ["jfandy1982"],
+  "ignoreWords": ["actionlint", "jfandy1982", "rhysd"],
   "words": ["Mattraks"]
 }

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,13 @@
+name: Local ActionLint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable/reusable-actionlint.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/reusable/reusable-actionlint.yml
+++ b/.github/workflows/reusable/reusable-actionlint.yml
@@ -1,0 +1,13 @@
+name: Reusable - actionlint
+
+on:
+  workflow_call:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/actionlint-action@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12

--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ jobs:
 ```
 
 The calling workflow is responsible for defining its own trigger (schedule, dispatch, etc.). No inputs required.
+
+### Actionlint (`reusable/reusable-actionlint.yml`)
+
+Lints all GitHub Actions workflow files in the calling repository using [actionlint](https://github.com/rhysd/actionlint).
+
+**Usage in other repos:**
+
+```yaml
+jobs:
+  actionlint:
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable/reusable-actionlint.yml@main
+    permissions:
+      contents: read
+```
+
+The calling workflow is responsible for defining its own trigger (schedule, dispatch, etc.). No inputs required.


### PR DESCRIPTION
## Summary

- Adds `reusable/reusable-actionlint.yml` — reusable workflow that lints GitHub Actions workflow files using `rhysd/actionlint-action` (SHA-pinned)
- Adds `actionlint.yml` — local caller workflow triggered on `pull_request` (scoped to `.github/workflows/**`) and `workflow_dispatch`
- Documents the actionlint reusable workflow in `README.md`
- Adds `actionlint` and `rhysd` to `.cspell.json` ignore list

## Notes

- `permissions: contents: read` is declared at the job level in the caller - the reusable workflow does not declare permissions itself, so callers must include it explicitly
- `push` trigger intentionally omitted — PR checks are sufficient; post-merge triggers will be handled by a dedicated orchestrator workflow in the future
- Consumer repos must allowlist `rhysd/actionlint-action@*` in their repo Actions settings for the workflow to run successfully