### PR TITLE
fix: forward pull-requests write permission to actionlint reusable workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,3 +11,4 @@ jobs:
     uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-actionlint.yml@main
     permissions:
       contents: read
+      pull-requests: write

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
     uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-actionlint.yml@main
     permissions:
       contents: read
+      pull-requests: write
 ```
 
 The calling workflow is responsible for defining its own trigger. No inputs required.


### PR DESCRIPTION
## Summary

- Adds `pull-requests: write` to the caller workflow `actionlint.yml` so the reusable workflow can write PR annotations
- Updates `README.md` usage example to reflect the required permissions

## Notes

- `devops-actions/actionlint` needs `pull-requests: write` in the caller to post inline annotations on workflow file issues in PRs
- Without this, the action runs but annotations are silently dropped