### PR TITLE
chore: add readable job names to all workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   actionlint:
+    name: Lint Workflow Files
     uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-actionlint.yml@main
     permissions:
       contents: read

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   retention:
+    name: Apply Retention Policy
     uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-retention-workflow-runs.yml@main
     permissions:
       actions: write

--- a/.github/workflows/reusable-actionlint.yml
+++ b/.github/workflows/reusable-actionlint.yml
@@ -5,10 +5,13 @@ on:
 
 jobs:
   actionlint:
+    name: Run actionlint
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-      - uses: devops-actions/actionlint@9fb9c192862f19e684586ca84b500461bcd8a541 #v0.1.12
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - name: Scan workflow files
+        uses: devops-actions/actionlint@9fb9c192862f19e684586ca84b500461bcd8a541 #v0.1.12

--- a/.github/workflows/reusable-retention-workflow-runs.yml
+++ b/.github/workflows/reusable-retention-workflow-runs.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   delete-runs:
+    name: Delete Workflow Runs
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
## Summary

- Adds `name:` fields to all workflow jobs and steps so the GitHub Actions UI shows readable labels instead of raw job keys
- UI will now display:
  - `Lint Workflow Files / Run actionlint` (previously `actionlint / actionlint`)
  - `Housekeeping / Apply Retention Policy` (previously `retention / delete-runs`)
- Step names added to `reusable-actionlint.yml`: `Checkout` and `Scan workflow files`