### PR TITLE
feat: add reusable stale-issues workflow

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -12,3 +12,8 @@ jobs:
     permissions:
       actions: write
       contents: read
+  stale-issues:
+    name: Mark Stale Issues
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-stale-issues.yml@main
+    permissions:
+      issues: write

--- a/.github/workflows/reusable-stale-issues.yml
+++ b/.github/workflows/reusable-stale-issues.yml
@@ -1,0 +1,25 @@
+name: Reusable - Stale Issues
+
+on:
+  workflow_call:
+
+jobs:
+  stale:
+    name: Mark and Close Stale Issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Mark and close stale issues
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 #v10.3.0
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: -1
+          stale-issue-label: 'status: stale'
+          exempt-issue-labels: 'status: pinned'
+          stale-issue-message: >
+            This issue has been automatically marked **stale** because it has had no activity for 60 days. It will be closed in 14 days if no further activity occurs. Add the `status: pinned` label to exempt it from this automation.
+
+          close-issue-message: >
+            This issue was closed because it has been stale for 14 days with no further activity.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ jobs:
 ```
 
 The calling workflow is responsible for defining its own trigger. No inputs required.
+
+### Stale Issues (`reusable-stale-issues.yml`)
+
+Marks issues stale after 60 days of inactivity and closes them 14 days later, using the `status: stale` label. Issues labeled `status: pinned` are exempt. Pull requests are not affected.
+
+**Usage in other repos:**
+
+```yaml
+jobs:
+  stale-issues:
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-stale-issues.yml@main
+    permissions:
+      issues: write
+```
+
+The calling workflow is responsible for defining its own trigger. No inputs required. Requires the `status: stale` and `status: pinned` labels to exist in the calling repository.


### PR DESCRIPTION
What: Adds reusable-stale-issues.yml wrapping actions/stale (60d stale / 14d close, issues only, status: pinned exempt, status: stale label, custom messages with accurate day counts), wires it into housekeeping.yml as a new job on the existing weekly cron, and documents it in README.md.
Why: Automates issue triage across repos using the status: stale / status: pinned labels already rolled out, keeping open issues under control without manual review.

## File risk

### 🟡 Medium

- `.github/workflows/housekeeping.yml` — adds stale-issues job on existing weekly cron
- `.github/workflows/reusable-stale-issues.yml` — new reusable workflow wrapping actions/stale

### 🟢 Low

- `README.md` — documents the new reusable-stale-issues workflow