### PR TITLE
chore: remove local renovate schedule in favor of central schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jfandy1982/.github//renovate-base.json"],
-  "schedule": ["after 5am and before 6am on Friday"]
+  "extends": ["github>jfandy1982/.github//renovate-base.json"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This is the GitHub repository containing reusable GitHub Workflows.
 ## Tooling
 
 - GitHub Actions SHAs are manually verified and pinned — do not flag pinned SHAs as outdated without checking first
-- Renovate: `renovate.json` in `.github/` is the repository-specific Renovate entry point; the `schedule` override there is intentional
+- Renovate: `renovate.json` in `.github/` is the repository-specific Renovate entry point, extending the shared `renovate-base.json` (schedule, labels, automerge rules); repo-specific `packageRules` overrides go here when needed
 - pre-commit hook runs `lint-staged` (Prettier + cspell) on `*.json`, `*.md`, `*.yml`; additionally runs `js-yaml` syntax validation on `*.yml`, `*.yaml`
 - Workflow `name:` field convention: `Reusable - <Purpose>` for reusable workflows, `Local <Purpose>` for orchestrators
 


### PR DESCRIPTION
## What

Removes the local `schedule` override from `.github/renovate.json`, leaving only the `extends`. Updates the `CLAUDE.md` Renovate line to describe the config as inheriting schedule/labels/automerge rules from the shared base, with repo-specific `packageRules` as the intended place for future overrides.

## Why

`renovate-base.json` in `jfandy1982/.github` now centrally defines a shared `after 5am and before 5pm on Friday` schedule for all consuming repos, replacing the previously duplicated per-repo 1-hour windows. This repo's local override is redundant now and is removed to avoid drift between the central and local config.

## File risk

### 🟢 Low

- `.github/renovate.json` — removes local schedule override, now inherits centrally
- `CLAUDE.md` — doc update reflecting inheritance